### PR TITLE
Update lec_3.tex

### DIFF
--- a/computability/semester_4/lec_3.tex
+++ b/computability/semester_4/lec_3.tex
@@ -264,7 +264,7 @@ $ U(n, \overline{x})$ --- \selectedFont{универсальная} для кл�
 		\exists n \colon  U_n(y) = g(y)
 	.\] 
 	\begin{align*}
-		& U'(n, c(\overline{x})) &=  \tag{по определению  $U$} \\
+		& U'(n, \overline{x}) &=  \tag{по определению  $U$} \\
 		&=U(n, c(\overline{x})) &= \tag{$ n$ -- номер $g$} \\
 		&=g(c(\overline{x})) &= \tag{по определению $g$} \\
 		&= f(c_1(c(\overline{x})), \ldots c_{m}(c(\overline{x})))&= f(\overline{x})


### PR DESCRIPTION
Typo: U' is (m+1)-ary, not binary function, therefore no need for cantor enumeration.